### PR TITLE
Fix issue with extension check

### DIFF
--- a/donut.c
+++ b/donut.c
@@ -478,32 +478,33 @@ static int read_file_info(PDONUT_CONFIG c) {
       return DONUT_ERROR_FILE_INVALID;
     }
     DPRINT("Extension is \"%s\"", ext);
-
+    
     // VBScript?
-    if (strcasecmp(ext, ".vbs") == 0) {
-      DPRINT("File is VBS");
+    if (strcasecmp(ext, ".vbs")) {
+      DPRINT("File is VBS. Because \"%s\" == \"%s\"", ext, ".vbs");
       fi.type = DONUT_MODULE_VBS;
       fi.arch = DONUT_ARCH_ANY;
     } else 
     // JScript?
-    if (strcasecmp(ext,  ".js") == 0) {
+    if (strcasecmp(ext,  ".js")) {
       DPRINT("File is JS");
       fi.type = DONUT_MODULE_JS;
       fi.arch = DONUT_ARCH_ANY;
-    } else 
-    // EXE?
-    if (strcasecmp(ext, ".exe") == 0) {
-      DPRINT("File is EXE");
+    } else // EXE?
+    if (strcasecmp(ext, ".exe")) {
+      DPRINT("File is EXE. Because \"%s\" == \"%s\"", ext, ".exe");
       fi.type = DONUT_MODULE_EXE;
     } else
     // DLL?
-    if (strcasecmp(ext, ".dll") == 0) {
-      DPRINT("File is DLL");
+    if (strcasecmp(ext, ".dll")) {
+      DPRINT("File is DLL. Because \"%s\" == \"%s\"", ext, ".dll");
       fi.type = DONUT_MODULE_DLL;
-    } else {
+    } else 
+    {
       DPRINT("Don't recognize file extension.");
       return DONUT_ERROR_FILE_INVALID;
     }
+
     
     DPRINT("Mapping %s into memory", c->input);
     


### PR DESCRIPTION
Hi man, the syscall version was not working because the file check against the binary was not working when compiled with MSVC.  Indeed, when MSVC is used, the unistd function strcasecmp is replaced by stricmp. However, completely unexpectedely, while `strcasecmp` return 0 when the two strings are equal, the custom implementation `stricmp` return 0 when they are different. Indeed, following through the definition in `donut.h`:

```
#if defined(_MSC_VER)
#pragma comment(lib, "advapi32.lib")
#pragma comment(lib, "user32.lib")
#define strcasecmp stricmp
```

And if we go and ivestigate in in `clib.c`, we can see that the `stricmp` implementation is:

```
int stricmp(const char *str1, const char *str2) {
    while (*str1 && *str2) {
      if ((*str1 | 0x20) != (*str2 | 0x20)) {
        return 0;
      }
      str1++; str2++;
    }
    return *str2 == 0;
}
```
Which evidentely return 0 if the two strings are different.